### PR TITLE
Update to add in-swarm HDFS Exporter.

### DIFF
--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -188,3 +188,11 @@ services:
       - "solr-proxy:192.168.45.33"
       - "www.webarchive.org.uk:192.168.45.10"
       - "beta.webarchive.org.uk:192.168.45.94"
+
+  # Also export HDFS stats scraped from the front page:
+  hdfs-exporter:
+    image: ukwa/hdfs-exporter
+     - 9118:9118
+    environment:
+     - "HDFS_HEALTH_PAGE=http://namenode.api.wa.bl.uk/dfshealth.jsp"
+

--- a/monitor/prometheus/prometheus.yml-template
+++ b/monitor/prometheus/prometheus.yml-template
@@ -237,7 +237,7 @@ scrape_configs:
 
   - job_name: 'hdfs-prod'
     static_configs:
-      - targets: ['ingest:9118']
+      - targets: ['hdfs-exporter:9118']
 
   - job_name: 'webhdfs'
     static_configs:


### PR DESCRIPTION
This change updates the configuration to deploy the HDFS exporter as part of the monitoring stack. It scrapes the DFS Health page from the new API endpoint and Prometheus can pick it up from there.