### PR TITLE
Minor updates to monitoring to reduce noise.

### DIFF
--- a/monitor/alertmanager/config.yml-template
+++ b/monitor/alertmanager/config.yml-template
@@ -4,10 +4,7 @@ global:
   smtp_from: "alertmanager@${ALERTMANAGER_SERVICE_NAME}"
   smtp_require_tls: false
 
-  # Slack basic config:
-  slack_api_url: '${SLACK_WEBHOOK_URL}'
-
-  # Plus proxy so we can get to Slack:
+  # Plus proxy so we can get to external alert services:
   http_config:
     proxy_url: '${HTTP_PROXY}'
 
@@ -43,26 +40,15 @@ route:
   # A default receiver
   receiver: 'wa-sysadm'
 
-  # Additional routes:
-  #routes:
-  #- receiver: 'slack-notifications'
-
 receivers:
 - name: 'wa-sysadm'
   # Send email:
   email_configs:
   - to: "${ALERT_EMAIL}"
 
-  # Also sent Pushover notifications:
+  # Also sent Pushover notifications (for ANJ):
   pushover_configs:
   - user_key: '${PUSHOVER_USER_KEY}'
     token: '${PUSHOVER_APP_TOKEN}'
     send_resolved: true
     retry: 1h
-
-# Slack updates (not in use at present):
-- name: 'slack-notifications'
-  slack_configs:
-  - channel: '#alerts'
-    send_resolved: true
-

--- a/monitor/alertmanager/config.yml-template
+++ b/monitor/alertmanager/config.yml-template
@@ -21,7 +21,7 @@ route:
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
-  group_by: ['alertname', 'cluster', 'service']
+  group_by: ['alertname', 'job']
 
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
@@ -36,32 +36,33 @@ route:
 
   # If an alert has successfully been sent, wait 'repeat_interval' to
   # resend them.
-  repeat_interval: 3h
+  repeat_interval: 12h
 
   # Say when the problem goes away:
 
   # A default receiver
-  receiver: 'wa-sysadm-mails'
+  receiver: 'wa-sysadm'
 
   # Additional routes:
-  routes:
-  - receiver: 'pushover-notifications-anj'
+  #routes:
   #- receiver: 'slack-notifications'
 
 receivers:
-- name: 'wa-sysadm-mails'
+- name: 'wa-sysadm'
+  # Send email:
   email_configs:
   - to: "${ALERT_EMAIL}"
 
-- name: 'slack-notifications'
-  slack_configs:
-  - channel: '#alerts'
-    send_resolved: true
-
-- name: 'pushover-notifications-anj'
+  # Also sent Pushover notifications:
   pushover_configs:
   - user_key: '${PUSHOVER_USER_KEY}'
     token: '${PUSHOVER_APP_TOKEN}'
     send_resolved: true
+    retry: 1h
 
+# Slack updates (not in use at present):
+- name: 'slack-notifications'
+  slack_configs:
+  - channel: '#alerts'
+    send_resolved: true
 

--- a/monitor/alertmanager/config.yml-template
+++ b/monitor/alertmanager/config.yml-template
@@ -41,11 +41,15 @@ route:
   # Say when the problem goes away:
 
   # A default receiver
-  #receiver: team-X-mails
-  receiver: 'slack-notifications'
+  receiver: 'wa-sysadm-mails'
+
+  # Additional routes:
+  routes:
+  - receiver: 'pushover-notifications-anj'
+  #- receiver: 'slack-notifications'
 
 receivers:
-- name: 'team-X-mails'
+- name: 'wa-sysadm-mails'
   email_configs:
   - to: "${ALERT_EMAIL}"
 
@@ -53,4 +57,11 @@ receivers:
   slack_configs:
   - channel: '#alerts'
     send_resolved: true
+
+- name: 'pushover-notifications-anj'
+  pushover_configs:
+  - user_key: '${PUSHOVER_USER_KEY}'
+    token: '${PUSHOVER_APP_TOKEN}'
+    send_resolved: true
+
 

--- a/monitor/alertmanager/config.yml-template
+++ b/monitor/alertmanager/config.yml-template
@@ -4,6 +4,14 @@ global:
   smtp_from: "alertmanager@${ALERTMANAGER_SERVICE_NAME}"
   smtp_require_tls: false
 
+  # Slack basic config:
+  slack_api_url: '${SLACK_WEBHOOK_URL}'
+
+  # Plus proxy so we can get to Slack:
+  http_config:
+    proxy_url: '${HTTP_PROXY}'
+
+
 # The directory from which notification templates are read.
 templates:
 - '/etc/alertmanager/template/*.tmpl'
@@ -30,10 +38,19 @@ route:
   # resend them.
   repeat_interval: 3h
 
+  # Say when the problem goes away:
+
   # A default receiver
-  receiver: team-X-mails
+  #receiver: team-X-mails
+  receiver: 'slack-notifications'
 
 receivers:
 - name: 'team-X-mails'
   email_configs:
   - to: "${ALERT_EMAIL}"
+
+- name: 'slack-notifications'
+  slack_configs:
+  - channel: '#alerts'
+    send_resolved: true
+

--- a/monitor/dev/start_monitor.sh
+++ b/monitor/dev/start_monitor.sh
@@ -8,13 +8,14 @@ export VISUALIZER_PORT=8081
 export GRAFANA_PORT=3000
 export PROMETHEUS_PORT=9090
 export ALERTMANAGER_PORT=9093
-export DATA_GRAFANA=/mnt/nfs/data/ukwa-monitor/grafana
-export DATA_PROMETHEUS=/mnt/nfs/data/ukwa-monitor/prometheus
-export DATA_ALERTMANAGER=/mnt/nfs/data/ukwa-monitor/alertmanager
+export DATA_PREFIX=/mnt/nfs/data
+export DATA_GRAFANA=${DATA_PREFIX}/ukwa-monitor/grafana
+export DATA_PROMETHEUS=${DATA_PREFIX}/ukwa-monitor/prometheus
+export DATA_ALERTMANAGER=${DATA_PREFIX}/ukwa-monitor/alertmanager
 export HTTP_PROXY=http://explorer2:3128/
 export HDFS_EXPORTER='hdfs-exporter.dapi.wa.bl.uk:80'
 
-export ALERT_EMAIL='gil.hoggarth@bl.uk'
+export ALERT_EMAIL='andrew.jackson@bl.uk'
 
 source ~/gitlab/ukwa-monitor/monitoring.sh
 cd ../

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -188,3 +188,11 @@ services:
       - "solr-proxy:192.168.45.33"
       - "www.webarchive.org.uk:192.168.45.10"
       - "beta.webarchive.org.uk:192.168.45.94"
+
+  # Also export HDFS stats scraped from the front page:
+  hdfs-exporter:
+    image: ukwa/hdfs-exporter
+     - 9118:9118
+    environment:
+     - "HDFS_HEALTH_PAGE=http://namenode.api.wa.bl.uk/dfshealth.jsp"
+

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -150,6 +150,8 @@ services:
       - '--config.file=/etc/alertmanager/config.yml'
       - '--storage.path=/alertmanager'
       - '--web.external-url=http://${ALERTMANAGER_SERVICE_NAME}/'
+    extra_hosts:
+      - "explorer2:192.168.45.3"
 
   pushgateway:
     image: prom/pushgateway
@@ -163,6 +165,8 @@ services:
       - http_proxy=${HTTP_PROXY}
     ports:
       - "9429:9429"
+    extra_hosts:
+      - "explorer2:192.168.45.3"
 
   blackbox-exporter:
     image: prom/blackbox-exporter
@@ -188,11 +192,4 @@ services:
       - "solr-proxy:192.168.45.33"
       - "www.webarchive.org.uk:192.168.45.10"
       - "beta.webarchive.org.uk:192.168.45.94"
-
-  # Also export HDFS stats scraped from the front page:
-  hdfs-exporter:
-    image: ukwa/hdfs-exporter
-     - 9118:9118
-    environment:
-     - "HDFS_HEALTH_PAGE=http://namenode.api.wa.bl.uk/dfshealth.jsp"
 

--- a/monitor/prometheus/alert.rules.yml
+++ b/monitor/prometheus/alert.rules.yml
@@ -95,7 +95,7 @@ groups:
  
   - alert: fc_crawl_is_slow
     expr: sum(rate(kafka_log_logendoffset{topic="fc.crawled"}[10m])) < 5
-    for: 10m
+    for: 30m
     labels:
       severity: severe
     annotations:

--- a/monitor/prometheus/alert.rules.yml
+++ b/monitor/prometheus/alert.rules.yml
@@ -101,5 +101,13 @@ groups:
     annotations:
       summary: "The frequent crawl is not running as fast as expected!"
       description: "The frequent crawl does not appear to be running as fast as it should be."
- 
 
+  - alert: cpu_running_too_hot
+    expr: max(node_hwmon_temp_celsius) by (instance) > 70
+    for: 30m
+    labels:
+      severity: severe
+    annotations:
+      summary: "CPU running too hot?"
+      description: "The CPU on {{ $labels.instance }} is running hot (>70C for 30mins)."
+ 

--- a/monitor/prometheus/prometheus.yml-template
+++ b/monitor/prometheus/prometheus.yml-template
@@ -237,7 +237,7 @@ scrape_configs:
 
   - job_name: 'hdfs-prod'
     static_configs:
-      - targets: ['ingest:9118']
+      - targets: ['hdfs-exporter:9118']
 
   - job_name: 'webhdfs'
     static_configs:


### PR DESCRIPTION
This set of changes:

- Avoids the 'slow crawl' warning firing unnecessarily.
- Ensures services that need `explorer2` can resolve the name.
- Route messages to @anjackson via https://pushover.net/ as well as email.
- Make notifications repeat less frequently.