### PR TITLE
Add DC monitoring config.

### DIFF
--- a/monitor/prometheus/prometheus.yml-template
+++ b/monitor/prometheus/prometheus.yml-template
@@ -264,6 +264,26 @@ scrape_configs:
         - 'crawler05:9191'
 
 
+  - job_name: 'federate-dc'
+    scrape_interval: 30s
+
+    honor_labels: true
+    metrics_path: '/federate'
+
+    params:
+      'match[]':
+        - '{job="npld-heritrix-workers"}'
+        - '{job="kafka"}'
+
+    # Only accessible via explorer2:
+    proxy_url: '192.168.45.3:3128'
+
+    static_configs:
+      - targets:
+        - 'crawler07.bl.uk:9191'
+
+
+
 #  - job_name: 'container-metrics'
 #    static_configs:
 #      - targets: ['access:8389', 'ingest:8389']


### PR DESCRIPTION
This is an untested configuration change, intended to add the DC Prometheus instance to our main monitoring system, as a federated source.
