### PR TITLE
Refinements and alerts

### DIFF
--- a/monitor/dev/prometheus-reload-cfg.sh
+++ b/monitor/dev/prometheus-reload-cfg.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -v -X POST http://monitor-prometheus.dapi.wa.bl.uk/-/reload
+

--- a/monitor/prometheus/alert.rules.yml
+++ b/monitor/prometheus/alert.rules.yml
@@ -1,8 +1,71 @@
 groups:
-- name: trackdb
+- name: UKWA metrics
   rules:
+  - alert: db_backup_failed
+    expr: absent(ukwa_database_backup_size_bytes)
+    for: 24h
+    labels:
+      severity: severe
+    annotations:
+      summary: "Databse back instance {{ $labels.instance }} failed to run"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} failed to run."
+
+  - alert: daily_access_task_is_missing
+    expr: absent(ukwa_task_event_timestamp{job="DailyAccessTasks"})
+    for: 24h
+    labels:
+      severity: severe
+    annotations:
+      summary: "Task {{ $labels.job }} failed to run"
+      description: "Job {{ $labels.job }} failed to run successfully."
+  
+  - alert: daily_ingest_task_is_missing
+    expr: absent(ukwa_task_event_timestamp{job="DailyIngestTasks"})
+    for: 24h
+    labels:
+      severity: severe
+    annotations:
+      summary: "Task {{ $labels.job }} failed to run"
+      description: "Job {{ $labels.job }} failed to run successfully."
+
+  - alert: daily_task_has_not_run
+    expr: (time() - ukwa_task_event_timestamp{job=~"DailyAccessTasks|DailyIngestTasks", status="event.core.success"} ) / (60*60) > 24
+    for: 2h
+    labels:
+      severity: severe
+    annotations:
+      summary: "Task {{ $labels.job }} failed to run"
+      description: "Job {{ $labels.job }} failed to run successfully."
+
+  - alert: nominet_task_has_not_run
+    expr: absent(ukwa_task_event_timestamp{job="NominetDomainListToHDFS"}) or (time() - ukwa_task_event_timestamp{job="NominetDomainListToHDFS", status="event.core.success"} ) / (60*60*24) > 31
+    for: 2h
+    labels:
+      severity: severe
+    annotations:
+      summary: "Task {{ $labels.job }} failed to run"
+      description: "Job {{ $labels.job }} failed to run successfully."
+
+  - alert: crawl_launcher_has_not_run
+    expr: absent(ukwa_task_event_timestamp{job="crawl.LaunchCrawls"}) or (time() - ukwa_task_event_timestamp{job='crawl.LaunchCrawls', status="event.core.success"}) > 3600
+    for: 10m
+    labels:
+      severity: severe
+    annotations:
+      summary: "Task {{ $labels.job }} failed to run"
+      description: "Job {{ $labels.job }} failed to run successfully."
+  
+  - alert: fc_crawl_is_slow
+    expr: sum(rate(kafka_log_logendoffset{topic="fc.crawled"}[10m])) < 5
+    for: 30m
+    labels:
+      severity: severe
+    annotations:
+      summary: "The frequent crawl is not running as fast as expected!"
+      description: "The frequent crawl does not appear to be running as fast as it should be."
+
   - alert: trackdb_daily_refresh_has_not_run
-    expr: (time() - trackdb_refresh_timestamp) / (60*60) > 24
+    expr: absent(trackdb_refresh_timestamp) or (time() - trackdb_refresh_timestamp) / (60*60) > 24
     for: 1h
     labels:
       severity: severe
@@ -10,7 +73,43 @@ groups:
       summary: "TrackDB not updated in last 24 hours"
       description: "{{ $labels.instance }} {{ $labels.job }} refresh_timestamp_dt hasn't changed in over 24 hours"
 
-- name: Core metrics
+  - alert: trackdb_no_new_warcs
+    expr: absent(trackdb_last_timestamp_warcs) or (time() - trackdb_last_timestamp_warcs) / (60 * 60) > 24
+    for: 2h
+    labels:
+      severity: severe
+    annotations:
+      summary: "No new WARCs on HDFS!"
+      description: "According to TrackDB, no new WARCs have turned up on HDFS lately."
+  
+  - alert: trackdb_no_new_warcs_cdxed
+    expr: absent(trackdb_last_timestamp_cdx) or (time() - trackdb_last_timestamp_cdx) / (60 * 60) > 24
+    for: 2h
+    labels:
+      severity: severe
+    annotations:
+      summary: "No WARCs have been CDX-indexed recently!"
+      description: "According to TrackDB, no new WARCs have been CDX-indexed lately."
+  
+  - alert: cdx_oa_no_new_mementos
+    expr: absent(cdx_oa_wayback_last_timestamp) or (time() - cdx_oa_wayback_last_timestamp) / (60 * 60) > 48
+    for: 2h
+    labels:
+      severity: severe
+    annotations:
+      summary: "No new Mementos available via OA Wayback!"
+      description: "According to the PyWB CDX API, no new content has turned up for a site we expect to visit every day."
+
+  - alert: trackdb_no_recent_rr_logs
+    expr: absent(trackdb_numFound_rr_logs) or trackdb_numFound_rr_logs != 10
+    for: 2h
+    labels:
+      severity: severe
+    annotations:
+      summary: "Missing Reading Room log files!"
+      description: "According to TrackDB, there are not the expected number (10) of up-to-date log files on HDFS."
+
+- name: Generic metrics
   rules:
 
   # Alert for any instance that is unreachable for >5 minutes.
@@ -50,15 +149,6 @@ groups:
       summary: "Disk space free < 5% on {{ $labels.instance }}"
       description: "Disk space free on {{ $labels.instance }} has been less that 5% for more than 5 minutes"
 
-  - alert: db_backup_failed
-    expr: absent(ukwa_database_backup_size_bytes)
-    for: 24h
-    labels:
-      severity: severe
-    annotations:
-      summary: "Databse back instance {{ $labels.instance }} failed to run"
-      description: "{{ $labels.instance }} of job {{ $labels.job }} failed to run."
-
   - alert: predict_host_disk_space
     expr: min(predict_linear(node_filesystem_free{mountpoint=~"/|/data"}[48h], 2*7*24*3600)) by (instance, mountpoint) < 0
     for: 1h
@@ -67,60 +157,6 @@ groups:
     annotations:
       summary: "Disk space running out on {{ $labels.instance }} at {{ $labels.mountpoint }}"
       description: "Based on recent sampling, the disk is likely to will fill on volume {{ $labels.mountpoint }} within the next two weeks, for instance: {{ $labels.instance }}."
-
-  - alert: daily_access_task_is_missing
-    expr: absent(ukwa_task_event_timestamp{job=~"DailyAccessTasks"})
-    for: 24h
-    labels:
-      severity: severe
-    annotations:
-      summary: "Task {{ $labels.job }} failed to run"
-      description: "Job {{ $labels.job }} failed to run successfully."
-
-  - alert: daily_ingest_task_is_missing
-    expr: absent(ukwa_task_event_timestamp{job=~"DailyIngestTasks"})
-    for: 24h
-    labels:
-      severity: severe
-    annotations:
-      summary: "Task {{ $labels.job }} failed to run"
-      description: "Job {{ $labels.job }} failed to run successfully."
-
-  - alert: daily_task_has_not_run
-    expr: (time() - ukwa_task_event_timestamp{job=~"DailyAccessTasks|DailyIngestTasks", status="event.core.success"} ) / (60*60) > 24
-    for: 2h
-    labels:
-      severity: severe
-    annotations:
-      summary: "Task {{ $labels.job }} failed to run"
-      description: "Job {{ $labels.job }} failed to run successfully."
-
-  - alert: nominet_task_has_not_run
-    expr: (time() - ukwa_task_event_timestamp{job="NominetDomainListToHDFS", status="event.core.success"} ) / (60*60*24) > 31
-    for: 2h
-    labels:
-      severity: severe
-    annotations:
-      summary: "Task {{ $labels.job }} failed to run"
-      description: "Job {{ $labels.job }} failed to run successfully."
-
-  - alert: crawl_launcher_has_not_run
-    expr: (time() - ukwa_task_event_timestamp{job='crawl.LaunchCrawls', status="event.core.success"}) > 3600
-    for: 10m
-    labels:
-      severity: severe
-    annotations:
-      summary: "Task {{ $labels.job }} failed to run"
-      description: "Job {{ $labels.job }} failed to run successfully."
- 
-  - alert: fc_crawl_is_slow
-    expr: sum(rate(kafka_log_logendoffset{topic="fc.crawled"}[10m])) < 5
-    for: 30m
-    labels:
-      severity: severe
-    annotations:
-      summary: "The frequent crawl is not running as fast as expected!"
-      description: "The frequent crawl does not appear to be running as fast as it should be."
 
   - alert: cpu_running_too_hot
     expr: max(node_hwmon_temp_celsius) by (instance) > 70

--- a/monitor/prometheus/prometheus.yml-template
+++ b/monitor/prometheus/prometheus.yml-template
@@ -189,7 +189,6 @@ scrape_configs:
         - "http://cdx.api.wa.bl.uk/data-heritrix"
         - "http://ingest:9001/act/login"
         - "http://ingest:9081/archive/"
-        - "http://hdfs.api.wa.bl.uk/webhdfs/v1/?user.name=tomcat&op=LISTSTATUS"
         - "http://access:8082/static/visualiser/index.html"
         - "http://ingest:8082/static/visualiser/index.html"
         - "http://intranet.wa.bl.uk/ukwa-reports/"

--- a/monitor/prometheus/prometheus.yml-template
+++ b/monitor/prometheus/prometheus.yml-template
@@ -55,6 +55,7 @@ scrape_configs:
         - 'jupyter2:9100'
         - 'wa-jupyter:9100'
         - 'wa-www:9100'
+        - 'wa-www:3903' # mtail http status metrics
 
   - job_name: 'gluster'
     static_configs:
@@ -218,6 +219,25 @@ scrape_configs:
         - "http://ingest:9001/act/login"
         - "http://ingest:9081/archive/"
         - "http://ingest:8082/static/visualiser/index.html"
+        - "http://crawldb-fc.api.wa.bl.uk/fc"
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115  
+
+  - job_name: 'hadoop-http'
+    metrics_path: /probe
+    scrape_timeout: 30s
+    params:
+      module: [http_2xx]  # Look for a HTTP 200 response.
+    static_configs:
+      - targets:
+        - "http://namenode.api.wa.bl.uk/dfshealth.jsp"
+        - "http://jobtracker.api.wa.bl.uk/jobtracker.jsp"
+        - "http://hdfs.api.wa.bl.uk/webhdfs/v1/?op=LISTSTATUS&user.name=access"
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/stat-pusher/dev.stats
+++ b/stat-pusher/dev.stats
@@ -59,8 +59,8 @@
 		"numFound_rr_logs": {
 			"host": "solr8",
 			"label": "logs",
-			"desc": "Number of reading-room catalina.out log files that have been updated in the last 24 hours.",
-			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=file_path_s%3A%5C%2Flogs%5C%2F*%5C%2Fopt%5C%2Ftomcat_instances%5C%2Fwayback%5C%2Flogs%5C%2Fcatalina.out%20AND%20timestamp_dt%3A%5BNOW-1DAY%20TO%20NOW%5D",
+			"desc": "Number of reading-room hdfs-sync log files that have been updated in the last 24 hours.",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=file_path_s%3A\\%2Flogs\\%2F*\\%2Fusr\\%2Flocal\\%2Fbin\\%2Fhdfslogsync.log-*%20AND%20timestamp_dt%3A[NOW-1DAY%20TO%20NOW]",
 			"kind": "json",
 			"match": "['response','numFound']"
 		}

--- a/stat-pusher/dev.stats
+++ b/stat-pusher/dev.stats
@@ -55,6 +55,14 @@
 			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=cdx_index_ss%3A%5B*%20TO%20*%5D&sort=timestamp_dt%20desc&wt=json",
 			"kind": "json",
 			"match": "['response','docs','timestamp_dt']"
+		},
+		"numFound_rr_logs": {
+			"host": "solr8",
+			"label": "logs",
+			"desc": "Number of reading-room catalina.out log files that have been updated in the last 24 hours.",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=file_path_s%3A%5C%2Flogs%5C%2F*%5C%2Fopt%5C%2Ftomcat_instances%5C%2Fwayback%5C%2Flogs%5C%2Fcatalina.out%20AND%20timestamp_dt%3A%5BNOW-1DAY%20TO%20NOW%5D",
+			"kind": "json",
+			"match": "['response','numFound']"
 		}
 	},
 	"cdx_oa_wayback": {

--- a/stat-pusher/update_pushgateway_stats.py
+++ b/stat-pusher/update_pushgateway_stats.py
@@ -40,11 +40,11 @@ def main():
 		logging.error(f"statsfile [{settings.get('statsfile')}] to test for [{environ}] environment missing")	
 		sys.exit()
 
-	# declare registry, inside loop for service
-	registry = CollectorRegistry()
-
 	# loop through wa service stats
 	for job in statTests:
+		# declare registry per job, inside loop for each stat:
+		registry = CollectorRegistry()
+		
 		for stat in statTests[job]:
 			# get stat details
 			try:
@@ -66,11 +66,11 @@ def main():
 			# set pushgateway submission details
 			g = Gauge(name, desc, labelnames=['instance','label'], registry=registry)
 			g.labels(instance=host,label=label).set(value)
-			logging.debug(f"Added job [{job}] host [{host}] name [{name}] value [{value}]")
+			logging.info(f"Added job [{job}] host [{host}] name [{name}] value [{value}]")
 
-			# upload to push gateway
-			push_to_gateway(settings.get('pushgtw'), registry=registry, job=job)
-			logging.info(f"Uploaded {job} {stat} {value}")
+		# upload to push gateway
+		push_to_gateway(settings.get('pushgtw'), registry=registry, job=job)
+		logging.info(f"Uploaded all [{job}] stats.")
 
 	logging.info('Fin')
 


### PR DESCRIPTION
This change set:

- Adds alerts for many critical cases, like CDX lag.
- Fixes #21 for stats pusher.
- Add RR log count to stats pusher.
- Tidied the alerts up into two groups.
- Added wa-www mtail, and HDFS web endpoints to the monitoring configuration.