### PR TITLE
Monitor crawl logs and database backups

### DIFF
--- a/monitor/prometheus/alert.rules.yml
+++ b/monitor/prometheus/alert.rules.yml
@@ -92,6 +92,15 @@ groups:
       summary: "No new WARCs on HDFS!"
       description: "According to TrackDB, no new WARCs have turned up on HDFS lately."
   
+  - alert: trackdb_no_new_npld_crawl_logs
+    expr: absent(trackdb_last_timestamp{label="npld.crawl-logs"}) or (time() - trackdb_last_timestamp{label="npld.crawl-logs"}) / (60 * 60) > 24
+    for: 8h
+    labels:
+      severity: severe
+    annotations:
+      summary: "No new NPLD crawl logs on HDFS!"
+      description: "According to TrackDB, no new NPLD crawl logs have turned up on HDFS lately."
+  
   - alert: trackdb_no_new_warcs_cdxed
     expr: absent(trackdb_last_timestamp_cdx) or (time() - trackdb_last_timestamp_cdx) / (60 * 60) > 24
     for: 8h

--- a/stat-pusher/dev.stats
+++ b/stat-pusher/dev.stats
@@ -31,12 +31,21 @@
 			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=kind_s%3Awarcs&sort=timestamp_dt%20desc&wt=json",
 			"kind": "json",
 			"match": "['response','numFound']"
-		},		
+		},
 		"last_timestamp_warcs": {
 			"host": "solr8",
 			"label": "warcs",
 			"desc": "Most recent trackdb timestamp of the WARCs",
 			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=kind_s%3Awarcs&sort=timestamp_dt%20desc&wt=json",
+			"kind": "json",
+			"match": "['response','docs','timestamp_dt']"
+		},
+		"last_timestamp_crawl_logs_npld": {
+			"host": "solr8",
+			"name": "trackdb_last_timestamp",
+			"label": "npld.crawl-logs",
+			"desc": "Most recent trackdb timestamp of the NPLD crawl logs.",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=kind_s%3Acrawl-logs%20AND%20job_s:frequent-npld&sort=timestamp_dt%20desc&wt=json",
 			"kind": "json",
 			"match": "['response','docs','timestamp_dt']"
 		},
@@ -69,7 +78,7 @@
 			"name": "ukwa_database_backup_size_bytes",
 			"label": "shine",
 			"desc": "Size of backup of SQL database stored on HDFS.",
-			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=modified_at_dt%3A[NOW-1DAY%20TO%20NOW]%20AND%20file_path_s:%22/2_backups/shine/dev/shine_dump.sql%22&sort=refresh_date_dt%20desc&wt=json",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=modified_at_dt%3A[NOW-1DAY%20TO%20NOW]%20AND%20file_path_s:\\/2_backups\\/access\\/access_shinedb\\/shine.pgdump*&sort=timestamp_dt%20desc&wt=json",
 			"kind": "json",
 			"match": "['response','docs', 'file_size_l']"
 		},
@@ -78,7 +87,7 @@
 			"name": "ukwa_database_backup_size_bytes",
 			"label": "w3act",
 			"desc": "Size of backup of SQL database stored on HDFS.",
-			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=modified_at_dt%3A[NOW-1DAY%20TO%20NOW]%20AND%20file_path_s:%22/2_backups/w3act/dev/w3act_dump.sql%22&sort=refresh_date_dt%20desc&wt=json",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=modified_at_dt%3A[NOW-1DAY%20TO%20NOW]%20AND%20file_path_s:\\/2_backups\\/ingest\\/ife_prod_postgres\\/w3act.pgdump*&sort=timestamp_dt%20desc&wt=json",
 			"kind": "json",
 			"match": "['response','docs', 'file_size_l']"
 		}
@@ -88,7 +97,7 @@
 			"host": "www.webarchive.org.uk",
 			"label": "cdx",
 			"desc": "Most recent CDX timestamp of a page that should be crawled every day (bl.uk/robots.txt)",
-			"uri": "https://www.webarchive.org.uk/wayback/archive/cdx?url=https%3A%2F%2Fwww.bl.uk%2Frobots.txt&output=json&allowFuzzy=false&sort=reverse&limit=1",
+			"uri": "https://www.webarchive.org.uk/wayback/archive/cdx?url=https%3A%2F%2Fwww.bbc.co.uk%2Fnews&output=json&allowFuzzy=false&sort=reverse&limit=1",
 			"kind": "json",
 			"match": "['timestamp']"
 		}

--- a/stat-pusher/prod.stats
+++ b/stat-pusher/prod.stats
@@ -31,12 +31,21 @@
 			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=kind_s%3Awarcs&sort=timestamp_dt%20desc&wt=json",
 			"kind": "json",
 			"match": "['response','numFound']"
-		},		
+		},
 		"last_timestamp_warcs": {
 			"host": "solr8",
 			"label": "warcs",
 			"desc": "Most recent trackdb timestamp of the WARCs",
 			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=kind_s%3Awarcs&sort=timestamp_dt%20desc&wt=json",
+			"kind": "json",
+			"match": "['response','docs','timestamp_dt']"
+		},
+		"last_timestamp_crawl_logs_npld": {
+			"host": "solr8",
+			"name": "trackdb_last_timestamp",
+			"label": "npld.crawl-logs",
+			"desc": "Most recent trackdb timestamp of the NPLD crawl logs.",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=kind_s%3Acrawl-logs%20AND%20job_s:frequent-npld&sort=timestamp_dt%20desc&wt=json",
 			"kind": "json",
 			"match": "['response','docs','timestamp_dt']"
 		},
@@ -63,6 +72,24 @@
 			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=file_path_s%3A\\%2Flogs\\%2F*\\%2Fusr\\%2Flocal\\%2Fbin\\%2Fhdfslogsync.log-*%20AND%20timestamp_dt%3A[NOW-1DAY%20TO%20NOW]",
 			"kind": "json",
 			"match": "['response','numFound']"
+		},
+		"sql_backup_size_shine": {
+			"host": "solr8",
+			"name": "ukwa_database_backup_size_bytes",
+			"label": "shine",
+			"desc": "Size of backup of SQL database stored on HDFS.",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=modified_at_dt%3A[NOW-1DAY%20TO%20NOW]%20AND%20file_path_s:\/2_backups\/access\/access_shinedb\/shine.pgdump-*&sort=refresh_date_dt%20desc&wt=json",
+			"kind": "json",
+			"match": "['response','docs', 'file_size_l']"
+		},
+		"sql_backup_size_w3act": {
+			"host": "solr8",
+			"name": "ukwa_database_backup_size_bytes",
+			"label": "w3act",
+			"desc": "Size of backup of SQL database stored on HDFS.",
+			"uri": "http://solr8.api.wa.bl.uk/solr/tracking/select?q=modified_at_dt%3A[NOW-1DAY%20TO%20NOW]%20AND%20file_path_s:\/2_backups\/ingest\/ife_prod_postgres\/w3act.pgdump-*&sort=refresh_date_dt%20desc&wt=json",
+			"kind": "json",
+			"match": "['response','docs', 'file_size_l']"
 		}
 	},
 	"cdx_oa_wayback": {

--- a/stat-pusher/update_pushgateway_stats.py
+++ b/stat-pusher/update_pushgateway_stats.py
@@ -44,6 +44,8 @@ def main():
 	for job in statTests:
 		# declare registry per job, inside loop for each stat:
 		registry = CollectorRegistry()
+		# Store gauges by name, so we can re-use the same metrics with different labels:
+		gauges = {}
 		
 		for stat in statTests[job]:
 			# get stat details
@@ -69,9 +71,13 @@ def main():
 					value = stat_values.get_json_value(uri, match)
 
 				# set pushgateway submission details
-				g = Gauge(name, desc, labelnames=['instance','label'], registry=registry)
+				if name in gauges:
+					g = gauges[name]
+				else:
+					g = Gauge(name, desc, labelnames=['instance','label'], registry=registry)
+					gauges[name] = g
 				g.labels(instance=host,label=label).set(value)
-				logging.info(f"Added job [{job}] host [{host}] name [{name}] value [{value}]")
+				logging.info(f"Added job [{job}] host [{host}] name [{name}] label [{label}] value [{value}]")
 			except Exception as e:
 				logging.error(f"Match not found for job [{job}] stat [{stat}] missing\n[{e}]")
 


### PR DESCRIPTION
This patch adds hooks so the crawl logs and database backups can be monitored.  The crawl log check will enable us to spot if the crawler has stopped checkpointing properly.

As Prometheus conventions expect different instances of the same metric to be distinguished by labels, the stats pusher code has been modified to allow the same metric name to be re-used between different entries.