### PR TITLE
Update to restore the original job id for AWS node exporter

### DIFF
--- a/monitor/prometheus/prometheus.yml-template
+++ b/monitor/prometheus/prometheus.yml-template
@@ -299,7 +299,7 @@ scrape_configs:
       'match[]':
         - '{job="npld-dc-heritrix-workers"}'
         - '{job="kafka"}'
-        - '{job="aws_dc_node_exporter"}'
+        - '{job="aws-dc_node_exporter"}'
 
     # Only accessible via explorer2:
     proxy_url: 'http://192.168.45.3:3128/'


### PR DESCRIPTION
In DC2021 I accidentally changed the job ID but this broke the dashboard.  This reverts to the original job ID.