### PR TITLE
Removed alertmanager version

### DIFF
--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       - '--web.enable-lifecycle'
 
   alertmanager:
-    image: prom/alertmanager:v2.30.3
+    image: prom/alertmanager
     ports:
       - "${ALERTMANAGER_PORT}:9093"
     volumes:


### PR DESCRIPTION
As we're over our github rate limit, I've had to remove the version number specified for the alertmanager service.