### PR TITLE
use standard workflow, pass action context

### DIFF
--- a/.github/workflows/push-to-docker-hub.yml
+++ b/.github/workflows/push-to-docker-hub.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ukwa/ukwa-services/.github/workflows/push-to-docker-hub.yml@master
     with:
       image_name: ukwa/monitor-stat-pusher
+      context: ./stat-pusher
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Changes for

https://github.com/ukwa/ukwa-services/issues/77

Switch UKWA Docker image builds to standard workflow